### PR TITLE
fix: preserve injected HTTP client in SetConfig method

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,79 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+genapi is a declarative HTTP client generator for Go that creates HTTP clients from interface definitions with annotations. It follows a code generation approach where interfaces are parsed, annotated with HTTP method details, and compiled into client implementations.
+
+## Key Architecture Components
+
+- **Code Generation Pipeline**: `internal/build/` contains the three-stage pipeline:
+  - `parser/` - Parses Go interface definitions and annotations
+  - `binder/` - Binds parsed data to internal representations 
+  - `generator/` - Generates concrete client implementations
+- **Runtime System**: `internal/runtime/` provides the runtime client factory and registry
+- **HTTP Client Abstraction**: `pkg/clients/` contains pluggable HTTP client implementations (default `http`, optional `resty`)
+- **Interface Contract**: All generated clients implement `genapi.Interface` which requires `SetHttpClient(HttpClient)`
+
+## Development Commands
+
+### Core Development
+```bash
+# Run all tests across all Go modules
+make test
+
+# Run linters across all Go modules  
+make lint
+
+# Generate client code from interface definitions
+make generate
+# or directly: go generate ./...
+
+# Run all checks (lint + test)
+make all
+```
+
+### Single Test Execution
+```bash
+# Run tests in specific directory
+go test -v -race -count=1 ./internal/...
+
+# Run specific test
+go test -v -run TestSpecificFunction ./path/to/package
+```
+
+### Code Generation
+```bash
+# Generate client from interface file
+go run github.com/lexcao/genapi/cmd/genapi -file path/to/api.go
+
+# This creates api.gen.go with the concrete client implementation
+```
+
+### Website/Examples
+```bash
+# Run development website
+make website
+# or: go run ./website/server.go -dir ./website
+```
+
+## Module Structure
+
+This is a multi-module repository with separate `go.mod` files in:
+- Root module: Core genapi library
+- `pkg/clients/resty/`: Optional Resty HTTP client implementation  
+- `website/`: Development website and examples
+
+The Makefile automatically discovers and operates on all modules.
+
+## Generated Code Pattern
+
+Interfaces with `//go:generate` directives and genapi annotations become concrete clients:
+- Input: Interface with `@BaseURL`, `@GET`, `@POST` etc. annotations
+- Output: `*.gen.go` files with `Register` calls and client implementations
+- Runtime: `genapi.New[InterfaceType]()` creates configured client instances
+
+## HTTP Client Architecture
+
+The system supports pluggable HTTP clients through the `HttpClient` interface. Default is `pkg/clients/http`, with `pkg/clients/resty` as an alternative. Custom implementations must implement `SetConfig(Config)` and `Do(*Request) (*Response, error)`.

--- a/IMPROVEMENTS.md
+++ b/IMPROVEMENTS.md
@@ -1,0 +1,167 @@
+# genapi Codebase Improvements
+
+This document outlines identified improvements for the genapi codebase, categorized by priority and impact.
+
+## 🚨 Critical Issues (Fix Immediately)
+
+### 1. HTTP Client Configuration Bug
+**File:** `pkg/clients/http/http.go:27`  
+**Issue:** The `SetConfig` method overwrites the injected HTTP client with the default client:
+```go
+func (c *HttpClient) SetConfig(config internal.Config) {
+	c.client = http.DefaultClient  // BUG: This overwrites the injected client
+	c.config = config
+}
+```
+**Impact:** Breaks dependency injection completely - all clients use default HTTP client regardless of configuration  
+**Fix:** Remove line 27 entirely or conditionally set only if `c.client` is nil
+
+### 2. Registry Panic Handling
+**File:** `internal/runtime/registry/registry.go:48`  
+**Issue:** Registry panics instead of returning errors for missing registrations:
+```go
+if !ok {
+    panic(fmt.Sprintf("no registration for key: %s", key))
+}
+```
+**Impact:** Makes the library fragile in production environments  
+**Fix:** Return an error instead of panicking, update callers to handle errors
+
+## 🔒 Security Concerns
+
+### 3. File Permissions Issue
+**File:** `internal/build/build.go:39`  
+**Issue:** Generated files use hardcoded permissions:
+```go
+return os.WriteFile(output, content, 0644)
+```
+**Impact:** May be too permissive in some environments  
+**Fix:** Make file permissions configurable or use more restrictive defaults (0600)
+
+### 4. Command Execution in Tests
+**File:** `test/e2e/setup_test.go:43`  
+**Issue:** Executes arbitrary commands without validation:
+```go
+cmd := exec.Command(name, args...)
+```
+**Impact:** Potential security risk if test environment is compromised  
+**Fix:** Add input validation or use safer test setup approach
+
+### 5. URL Validation
+**Files:** `pkg/clients/http/http.go` (URL construction)  
+**Issue:** No validation of base URL format  
+**Impact:** Potential for malformed URLs or unsafe schemes  
+**Fix:** Add validation to ensure baseURL is well-formed, restrict to HTTPS in production
+
+## ⚡ Performance Issues
+
+### 6. Registry Lock Contention
+**File:** `internal/runtime/registry/registry.go`  
+**Issue:** Single RWMutex for all registry operations  
+**Impact:** Could cause contention under high load  
+**Fix:** Consider using `sync.Map` or more granular locking strategy
+
+### 7. Inefficient JSON Marshaling
+**File:** `pkg/clients/http/http.go`  
+**Issue:** JSON marshaling happens on every request without caching  
+**Impact:** Unnecessary CPU overhead for identical requests  
+**Fix:** Consider request body cache or allow pre-marshaled bodies
+
+### 8. String Building Optimization
+**Files:** URL resolution code  
+**Issue:** Multiple string operations could be optimized  
+**Impact:** Minor performance overhead  
+**Fix:** Use `strings.Builder` for complex string operations
+
+## 🧹 Code Quality Issues
+
+### 9. Context Handling
+**File:** `pkg/clients/http/http.go:34`  
+**Issue:** Uses `context.TODO()` instead of `context.Background()`:
+```go
+if ctx == nil {
+    ctx = context.TODO()
+}
+```
+**Impact:** Signals incomplete context handling  
+**Fix:** Use `context.Background()` or require context to be non-nil
+
+### 10. Naming Inconsistency
+**Files:** Various  
+**Issue:** Mix of `HttpClient` vs `HTTPClient` casing  
+**Impact:** Inconsistent with Go conventions  
+**Fix:** Standardize on `HTTPClient` per Go naming conventions
+
+### 11. Missing Interface Documentation
+**File:** `internal/genapi.go`  
+**Issue:** `Interface` type lacks comprehensive documentation  
+**Impact:** Poor developer experience  
+**Fix:** Add detailed documentation with usage examples
+
+### 12. Magic Strings in Tests
+**Files:** Various test files  
+**Issue:** Hardcoded strings and URLs throughout tests  
+**Impact:** Maintenance burden  
+**Fix:** Extract test constants to improve maintainability
+
+## 🧪 Testing Issues
+
+### 13. Missing Error Path Coverage
+**Files:** `internal/build/`, HTTP client tests  
+**Issue:** Many error paths not covered by tests  
+**Impact:** Potential bugs in error handling  
+**Fix:** Add tests for:
+- Invalid file inputs in build process
+- Network failures in HTTP clients  
+- Registry registration conflicts
+
+### 14. Registry Integration Tests
+**File:** `internal/runtime/registry/`  
+**Issue:** Lacks comprehensive integration tests  
+**Impact:** May miss bugs in registration → creation → usage flow  
+**Fix:** Add end-to-end registry functionality tests
+
+### 15. Custom Test Assertions
+**Files:** Various test files  
+**Issue:** Custom assertions instead of established patterns  
+**Impact:** Inconsistent with Go testing practices  
+**Fix:** Standardize on `testify` (already imported in some places)
+
+## 📦 Dependencies
+
+### 16. Go Version Consideration
+**File:** `go.mod`  
+**Current:** Go 1.18 minimum  
+**Impact:** Missing potential performance improvements  
+**Recommendation:** Consider Go 1.19+ for performance, but current version acceptable
+
+## Implementation Priority
+
+### Phase 1 - Critical Fixes
+- [x] Fix HTTP client configuration bug (#1) - ✅ FIXED: SetConfig now preserves injected clients
+- [ ] Replace registry panics with error handling (#2)
+- [ ] Add file permission configuration (#3)
+
+### Phase 2 - Security & Quality
+- [ ] Add input validation for tests (#4)
+- [ ] Implement URL validation (#5)
+- [ ] Fix context handling (#9)
+- [ ] Standardize naming conventions (#10)
+
+### Phase 3 - Performance & Testing
+- [ ] Optimize registry locking (#6)
+- [ ] Add comprehensive error path tests (#13)
+- [ ] Add registry integration tests (#14)
+
+### Phase 4 - Polish
+- [ ] Extract test constants (#12)
+- [ ] Improve documentation (#11)
+- [ ] Optimize string operations (#8)
+- [ ] Standardize test assertions (#15)
+
+## Notes
+
+- The codebase shows good architectural patterns overall
+- Minimal dependencies are a positive aspect (reduces supply chain risk)
+- Focus on critical issues first as they affect core functionality
+- Consider creating issues for tracking individual improvements

--- a/pkg/clients/http/http.go
+++ b/pkg/clients/http/http.go
@@ -24,7 +24,9 @@ type HttpClient struct {
 }
 
 func (c *HttpClient) SetConfig(config internal.Config) {
-	c.client = http.DefaultClient
+	if c.client == nil {
+		c.client = http.DefaultClient
+	}
 	c.config = config
 }
 


### PR DESCRIPTION
## Summary
• Fixed critical bug where `SetConfig` was overwriting injected HTTP clients with default client
• Preserves dependency injection while still handling nil client edge case
• Resolves Issue 1 from IMPROVEMENTS.md

## Changes
- Modified `pkg/clients/http/http.go` `SetConfig` method to conditionally set default client only when `c.client` is nil
- Updated `IMPROVEMENTS.md` to mark issue 1 as resolved

## Test plan
- [x] All existing tests pass
- [x] Linter passes
- [x] Custom HTTP clients are preserved when injected via `New(customClient)`
- [x] Default client is still set when client is nil (edge case protection)

🤖 Generated with [Claude Code](https://claude.ai/code)