### PR TITLE
fix: replace registry panics with proper error handling

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,7 +72,7 @@ The Makefile automatically discovers and operates on all modules.
 Interfaces with `//go:generate` directives and genapi annotations become concrete clients:
 - Input: Interface with `@BaseURL`, `@GET`, `@POST` etc. annotations
 - Output: `*.gen.go` files with `Register` calls and client implementations
-- Runtime: `genapi.New[InterfaceType]()` creates configured client instances
+- Runtime: `genapi.New[InterfaceType]()` creates configured client instances (returns client and error)
 
 ## HTTP Client Architecture
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,10 @@ import (
 )
 
 func main() {
-    client := genapi.New[api.GitHub]()
+    client, err := genapi.New[api.GitHub]()
+    if err != nil {
+        log.Fatalf("failed to create client: %v", err)
+    }
 
     contributors, err := client.Contributors(context.Background(), "lexcao", "genapi")
     if err != nil {
@@ -94,9 +97,12 @@ import (
 func main() {
     httpClient := &http_client.Client{}
 
-    client := genapi.New[api.GitHub](
+    client, err := genapi.New[api.GitHub](
         genapi.WithHttpClient(http.New(httpClient))
     )
+    if err != nil {
+        log.Fatalf("failed to create client: %v", err)
+    }
 
     // or set client in the runtime
     client.SetHttpClient(httpClient)
@@ -123,10 +129,13 @@ import (
 )
 
 func main() {
-	client := genapi.New[api.GitHub](
+	client, err := genapi.New[api.GitHub](
 		genapi.WithHttpClient(resty.DefaultClient),           // default Resty client
         genapi.WithHttpClient(resty.New(resty_client.New())), // customized Resty client
 	)
+	if err != nil {
+		log.Fatalf("failed to create client: %v", err)
+	}
 }
 ```
 
@@ -162,7 +171,7 @@ func TestHttpClient(t *testing.T) {
 The client can be configured with various options:
 
 ```go
-client := genapi.New[api.GitHub](
+client, err := genapi.New[api.GitHub](
     // Set runtime client
     genapi.WithHttpClient(resty.DefaultClient),
 
@@ -174,6 +183,9 @@ client := genapi.New[api.GitHub](
         "Authorization": "Bearer " + token,
     }),
 )
+if err != nil {
+    log.Fatalf("failed to create client: %v", err)
+}
 ```
 
 ## Documentation

--- a/examples/github/main.go
+++ b/examples/github/main.go
@@ -11,7 +11,11 @@ import (
 )
 
 func main() {
-	client := genapi.New[api.GitHub]()
+	client, err := genapi.New[api.GitHub]()
+	if err != nil {
+		fmt.Printf("failed to create client: %v\n", err)
+		return
+	}
 
 	contributors, err := client.Contributors(context.Background(), "lexcao", "genapi")
 	if err != nil {

--- a/genapi.go
+++ b/genapi.go
@@ -15,7 +15,7 @@ type HttpClientTester = internal.HttpClientTester
 type Option = runtime.Option
 type Options = runtime.Options
 
-func New[T Interface](opts ...Option) T {
+func New[T Interface](opts ...Option) (T, error) {
 	return runtime.New[T](opts...)
 }
 

--- a/genapi_test.go
+++ b/genapi_test.go
@@ -1,0 +1,58 @@
+package genapi
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestInterface for testing
+type TestInterface interface {
+	Interface
+	TestMethod() string
+}
+
+func TestNew_ErrorPropagation(t *testing.T) {
+	t.Run("ReturnsErrorForUnregisteredInterface", func(t *testing.T) {
+		// TestInterface is not registered in the registry
+		client, err := New[TestInterface]()
+		
+		// Should return an error
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no registration found for interface")
+		
+		// Client should be nil/zero value
+		assert.Nil(t, client)
+	})
+}
+
+// TestValidRegistration ensures that registered interfaces work correctly
+type ValidTestInterface interface {
+	Interface
+	ValidMethod() string
+}
+
+type validTestImpl struct {
+	client HttpClient
+}
+
+func (v *validTestImpl) SetHttpClient(client HttpClient) {
+	v.client = client
+}
+
+func (v *validTestImpl) ValidMethod() string {
+	return "valid"
+}
+
+func TestNew_ValidRegistration(t *testing.T) {
+	// Register a valid interface-implementation pair
+	Register[ValidTestInterface, *validTestImpl](Config{})
+	
+	client, err := New[ValidTestInterface]()
+	
+	// Should succeed
+	require.NoError(t, err)
+	require.NotNil(t, client)
+	assert.Equal(t, "valid", client.ValidMethod())
+}

--- a/internal/runtime/registry/registry.go
+++ b/internal/runtime/registry/registry.go
@@ -38,23 +38,24 @@ func Register[api any, client any](config ...any) {
 	}
 }
 
-func New[api any]() (api, any) {
+func New[api any]() (api, any, error) {
 	registry.lock.RLock()
 	defer registry.lock.RUnlock()
 
 	key := getKey[api]()
 	value, ok := registry.registration[key]
 	if !ok {
-		panic(fmt.Sprintf("no registration for key: %s", key))
+		var zero api
+		return zero, nil, fmt.Errorf("no registration found for interface %s.%s", key.pkg, key.name)
 	}
 
 	clientImpl := reflect.New(value.typ).Interface().(api)
 
 	if len(value.config) == 0 {
-		return clientImpl, nil
+		return clientImpl, nil, nil
 	}
 
-	return clientImpl, value.config[0]
+	return clientImpl, value.config[0], nil
 }
 
 func getKey[api any]() key {

--- a/internal/runtime/registry/registry_test.go
+++ b/internal/runtime/registry/registry_test.go
@@ -30,26 +30,30 @@ func TestRegistry(t *testing.T) {
 	t.Run("Simple", func(t *testing.T) {
 		t.Run("Local", func(t *testing.T) {
 			Register[Doer, implDoer]()
-			got, _ := New[Doer]()
+			got, _, err := New[Doer]()
+			assert.NoError(t, err)
 			assert.Equal(t, "done", got.Do())
 		})
 
 		t.Run("Config", func(t *testing.T) {
 			Register[Doer, implDoer](Config{Hello: "world"})
-			got, config := New[Doer]()
+			got, config, err := New[Doer]()
+			assert.NoError(t, err)
 			assert.Equal(t, "done", got.Do())
 			assert.Equal(t, Config{Hello: "world"}, config)
 		})
 
 		t.Run("Pointer", func(t *testing.T) {
 			Register[Doer, *implDoer]()
-			got, _ := New[Doer]()
+			got, _, err := New[Doer]()
+			assert.NoError(t, err)
 			assert.Equal(t, "done", got.Do())
 		})
 
 		t.Run("Package", func(t *testing.T) {
 			Register[simple.Valuer, *simple.ImplValuer]()
-			got, _ := New[simple.Valuer]()
+			got, _, err := New[simple.Valuer]()
+			assert.NoError(t, err)
 			assert.Equal(t, "Value from simple", got.Value())
 		})
 	})
@@ -59,10 +63,12 @@ func TestRegistry(t *testing.T) {
 			Register[pkg1.Valuer, *pkg1.ImplValuer]()
 			Register[pkg2.Valuer, *pkg2.ImplValuer]()
 
-			got, _ := New[pkg1.Valuer]()
+			got, _, err := New[pkg1.Valuer]()
+			assert.NoError(t, err)
 			assert.Equal(t, "Value from pkg1", got.Value())
 
-			got, _ = New[pkg2.Valuer]()
+			got, _, err = New[pkg2.Valuer]()
+			assert.NoError(t, err)
 			assert.Equal(t, "Value from pkg2", got.Value())
 		})
 
@@ -70,20 +76,22 @@ func TestRegistry(t *testing.T) {
 			Register[pkg1_value.Valuer, *pkg1_value.ImplValuer]()
 			Register[pkg2_value.Valuer, *pkg2_value.ImplValuer]()
 
-			got, _ := New[pkg1_value.Valuer]()
+			got, _, err := New[pkg1_value.Valuer]()
+			assert.NoError(t, err)
 			assert.Equal(t, "Value from pkg1.value", got.Value())
 
-			got, _ = New[pkg2_value.Valuer]()
+			got, _, err = New[pkg2_value.Valuer]()
+			assert.NoError(t, err)
 			assert.Equal(t, "Value from pkg2.value", got.Value())
 		})
 	})
 
-	t.Run("Panic", func(t *testing.T) {
+	t.Run("ErrorOnMissingRegistration", func(t *testing.T) {
 		type NotImpl interface {
 			NotImplemented() string
 		}
-		assert.Panics(t, func() {
-			New[NotImpl]()
-		})
+		_, _, err := New[NotImpl]()
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "no registration found for interface")
 	})
 }

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -6,8 +6,12 @@ import (
 	"github.com/lexcao/genapi/pkg/clients/http"
 )
 
-func New[T internal.Interface](opts ...Option) T {
-	api, config := registry.New[T]()
+func New[T internal.Interface](opts ...Option) (T, error) {
+	api, config, err := registry.New[T]()
+	if err != nil {
+		var zero T
+		return zero, err
+	}
 
 	// build options
 	options := &Options{
@@ -22,7 +26,7 @@ func New[T internal.Interface](opts ...Option) T {
 
 	// finish initialization
 	api.SetHttpClient(options.client())
-	return api
+	return api, nil
 }
 
 func Register[api internal.Interface, client internal.Interface](config internal.Config) {

--- a/pkg/clients/resty/README.md
+++ b/pkg/clients/resty/README.md
@@ -19,10 +19,13 @@ import (
 )
 
 func main() {
-	client := genapi.New[api.GitHub](
+	client, err := genapi.New[api.GitHub](
 		genapi.WithHttpClient(resty.DefaultClient),           // default Resty client
         genapi.WithHttpClient(resty.New(resty_client.New())), // customized Resty client
 	)
+	if err != nil {
+		log.Fatalf("failed to create client: %v", err)
+	}
 }
 ```
 

--- a/pkg/clients/resty/example/main.go
+++ b/pkg/clients/resty/example/main.go
@@ -12,9 +12,13 @@ import (
 )
 
 func main() {
-	client := genapi.New[api.GitHub](
+	client, err := genapi.New[api.GitHub](
 		genapi.WithHttpClient(resty.DefaultClient),
 	)
+	if err != nil {
+		fmt.Printf("failed to create client: %v\n", err)
+		return
+	}
 
 	contributors, err := client.Contributors(context.Background(), "lexcao", "genapi")
 	if err != nil {

--- a/pkg/clients/resty/go.mod
+++ b/pkg/clients/resty/go.mod
@@ -1,7 +1,8 @@
 module github.com/lexcao/genapi/pkg/clients/resty
 
-go 1.21
-toolchain go1.24.1
+go 1.23.0
+
+toolchain go1.24.5
 
 replace github.com/lexcao/genapi => ../../../
 

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -8,7 +8,8 @@ import (
 )
 
 func TestE2E(t *testing.T) {
-	client := genapi.New[HttpBin]()
+	client, err := genapi.New[HttpBin]()
+	require.NoError(t, err)
 
 	t.Run("get", func(t *testing.T) {
 		t.Parallel()

--- a/test/it/it_test.go
+++ b/test/it/it_test.go
@@ -14,9 +14,10 @@ func TestIntegration(t *testing.T) {
 	ts := httptest.NewServer(newServer(t))
 	t.Cleanup(ts.Close)
 
-	api := genapi.New[TestAPI](
+	api, err := genapi.New[TestAPI](
 		genapi.WithBaseURL(ts.URL),
 	)
+	require.NoError(t, err)
 
 	t.Run("get echo", func(t *testing.T) {
 		resp, err := api.GetEcho("123", "query")

--- a/website/index.html
+++ b/website/index.html
@@ -242,7 +242,10 @@ import (
 
 func main() {
     // Get API client instance
-    client := genapi.New[api.TodoAPI]()
+    client, err := genapi.New[api.TodoAPI]()
+    if err != nil {
+        log.Fatalf("Failed to create client: %v", err)
+    }
     
     // Fetch all todos
     todos, err := client.GetTodos(context.Background())
@@ -283,7 +286,10 @@ import (
 
 func main() {
     // Get API client instance
-    client := genapi.New[api.TodoAPI]()
+    client, err := genapi.New[api.TodoAPI]()
+    if err != nil {
+        log.Fatalf("Failed to create client: %v", err)
+    }
 
     // Customize standard Go http.Client
     customHttpClient := &http_client.Client{}
@@ -423,7 +429,10 @@ type UserAPI interface {
                                     <pre><code class="language-go">import "github.com/lexcao/genapi"
 
 // Create client
-client := genapi.New[api.UserAPI]()
+client, err := genapi.New[api.UserAPI]()
+if err != nil {
+    log.Fatalf("Failed to create client: %v", err)
+}
 
 // Use client with type safety
 users, err := client.GetUsers(context.Background())</code></pre>


### PR DESCRIPTION
## Summary
Replace panic-based error handling in registry with proper Go error patterns to make the library production-ready.

## Changes Made
- **Core Fix**: Updated `registry.New[T]()` signature from `(T, any)` to `(T, any, error)`
- **Error Propagation**: Updated `runtime.New[T]()` and `genapi.New[T]()` to handle and propagate errors
- **Call Site Updates**: Fixed all usage across:
  - Examples (github, resty examples)  
  - Tests (e2e, integration, registry tests)
  - Documentation (README.md, website, package docs)
- **Test Coverage**: Added comprehensive error handling tests in `genapi_test.go`

## Problem Solved
Previously, `genapi.New[UnregisteredInterface]()` would crash the entire application with a panic. Now it returns a descriptive error that applications can handle gracefully:

```go
// Before: This would panic and crash the app
client := genapi.New[api.UnregisteredAPI]()

// After: Proper error handling
client, err := genapi.New[api.UnregisteredAPI]()
if err \!= nil {
    log.Printf("API not available: %v", err)
    // Application continues running
}
```

## Test Plan
- [x] All existing tests pass with new error handling
- [x] New error scenario tests added and passing
- [x] Examples run successfully with error handling
- [x] Linting passes
- [x] No breaking changes to generated code (templates unchanged)

## Breaking Change Notice
This is a breaking change to the public API signature:
- `genapi.New[T]()` → `genapi.New[T]() (T, error)`

All call sites need to be updated to handle the error return value.

Fixes critical issue #2 from IMPROVEMENTS.md

🤖 Generated with [Claude Code](https://claude.ai/code)